### PR TITLE
Add DrawGraph with name

### DIFF
--- a/statefulGraph/stateMachineGraph.go
+++ b/statefulGraph/stateMachineGraph.go
@@ -55,7 +55,7 @@ func (smg StateMachineGraph) DrawEdges(graph *gographviz.Graph) error {
 
 func (smg StateMachineGraph) DrawGraph() error {
 	var err error
-	graph, err := initializeGraph()
+	graph, err := intializeGraphWithDir()
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func (smg StateMachineGraph) DrawGraph() error {
 
 func (smg StateMachineGraph) DrawGraphWithName(name string) error {
 	var err error
-	graph, err := initializeGraph()
+	graph, err := intializeGraphWithDir()
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (smg StateMachineGraph) DrawGraphWithName(name string) error {
 	return nil
 }
 
-func initializeGraph() (*gographviz.Graph, error) {
+func intializeGraphWithDir() (*gographviz.Graph, error) {
 	var err error
 	graph := gographviz.NewGraph()
 

--- a/statefulGraph/stateMachineGraph.go
+++ b/statefulGraph/stateMachineGraph.go
@@ -55,14 +55,56 @@ func (smg StateMachineGraph) DrawEdges(graph *gographviz.Graph) error {
 
 func (smg StateMachineGraph) DrawGraph() error {
 	var err error
-	graph := gographviz.NewGraph()
-
-	err = graph.SetDir(true)
+	graph, err := initializeGraph()
 	if err != nil {
 		return err
 	}
 
-	err = smg.DrawStates(graph)
+	err = smg.drawGraph(graph)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(graph.String())
+
+	return nil
+}
+
+func (smg StateMachineGraph) DrawGraphWithName(name string) error {
+	var err error
+	graph, err := initializeGraph()
+	if err != nil {
+		return err
+	}
+
+	err = graph.SetName(name)
+	if err != nil {
+		return err
+	}
+
+	err = smg.drawGraph(graph)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(graph.String())
+
+	return nil
+}
+
+func initializeGraph() (*gographviz.Graph, error) {
+	var err error
+	graph := gographviz.NewGraph()
+
+	err = graph.SetDir(true)
+	if err != nil {
+		return nil, err
+	}
+	return graph, nil
+}
+
+func (smg StateMachineGraph) drawGraph(graph *gographviz.Graph) error {
+	err := smg.DrawStates(graph)
 	if err != nil {
 		return err
 	}
@@ -71,8 +113,5 @@ func (smg StateMachineGraph) DrawGraph() error {
 	if err != nil {
 		return err
 	}
-
-	fmt.Println(graph.String())
-
 	return nil
 }


### PR DESCRIPTION
Hi @bykof, thank you for your great tool. It's very useful for me!

But I have a small issue for the `stateMachineGraph.DrawGraph` function.
I want to use the output graph on PlantUML, but it has a syntax error because there is no name.
If there is a function to add a name, it's more useful for PlantUML users.
What do you think about it?

Now I've created the PR to add a name by DrawGraphWithName function.